### PR TITLE
fixed a deadlock when create a database

### DIFF
--- a/src/UserStore.cs
+++ b/src/UserStore.cs
@@ -39,7 +39,12 @@ namespace DocumentDB.AspNet.Identity
             {
                 if (database == null)
                 {
-                    database = ReadOrCreateDatabase().Result;
+                    Task.Run(
+                        async () =>
+                        {
+                            database = await ReadOrCreateDatabase();
+                        }).Wait();
+
                 }
 
                 return database;
@@ -56,9 +61,15 @@ namespace DocumentDB.AspNet.Identity
             {
                 if (usersLink == null)
                 {
-                    var collection = InitializeConnection(Database.SelfLink, "Users").Result;
-                    usersLink = collection.DocumentsLink;
-                    usersSelfLink = collection.SelfLink;
+                    Task.Run(
+                        async () =>
+                        {
+                            var collection = await InitializeConnection(Database.SelfLink, "Users");
+                            usersLink = collection.DocumentsLink;
+                            usersSelfLink = collection.SelfLink;
+                        }).Wait();
+               
+                   
                     AddUserDefinedFunctionsIfNeeded(usersSelfLink);
                 }
                 return client.CreateDocumentQuery<TUser>(usersLink);


### PR DESCRIPTION
When the database is created for the first time there is a deadlock because of using
`
database = ReadOrCreateDatabase().Result;
`
In an asp.net application we don't use 'Result' <a href="http://blog.stephencleary.com/2012/07/dont-block-on-async-code.html">Don't Block</a>
