### PR TITLE
Fixed a bug when the JsonSerializerSettings are changed

### DIFF
--- a/src/IdentityUser.cs
+++ b/src/IdentityUser.cs
@@ -13,11 +13,13 @@ namespace DocumentDB.AspNet.Identity
         [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
+        [JsonProperty(PropertyName = "userName")]
         public string UserName { get; set; }
 
         /// <summary>
         ///     Email
         /// </summary>
+        [JsonProperty(PropertyName = "email")]
         public virtual string Email { get; set; }
 
         /// <summary>


### PR DESCRIPTION
In my configuration method I change a ``JsonSerializerSettings``
```
  JsonConvert.DefaultSettings = () =>
                new JsonSerializerSettings
                {
                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
                    NullValueHandling = NullValueHandling.Ignore,
                    MissingMemberHandling = MissingMemberHandling.Ignore,
                    DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
                    TypeNameHandling = TypeNameHandling.None,
                };
```
And with such settings I can register as many users with the same user name as I want.

This PR fixes the issue.