### PR TITLE
Add udf prefix to query

### DIFF
--- a/src/UserStore.cs
+++ b/src/UserStore.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Identity;
+using Microsoft.AspNet.Identity;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Linq;
 using Microsoft.Azure.Documents.Client;
@@ -104,7 +104,7 @@ namespace DocumentDB.AspNet.Identity
                 Task.Run(
                     () =>
                     {
-                        var query = client.CreateDocumentQuery<TUser>(usersLink, string.Format("SELECT * FROM Users u WHERE HasLogin(u.Logins, '{0}', '{1}') = true", login.ProviderKey, login.LoginProvider)).AsEnumerable();
+                        var query = client.CreateDocumentQuery<TUser>(usersLink, string.Format("SELECT * FROM Users u WHERE UDF.HasLogin(u.Logins, '{0}', '{1}') = true", login.ProviderKey, login.LoginProvider)).AsEnumerable();
                         var match = query.AsEnumerable().FirstOrDefault();
                         return match;
                     });

--- a/src/UserStore.cs
+++ b/src/UserStore.cs
@@ -104,7 +104,7 @@ namespace DocumentDB.AspNet.Identity
                 Task.Run(
                     () =>
                     {
-                        var query = client.CreateDocumentQuery<TUser>(usersLink, string.Format("SELECT * FROM Users u WHERE UDF.HasLogin(u.Logins, '{0}', '{1}') = true", login.ProviderKey, login.LoginProvider)).AsEnumerable();
+                        var query = client.CreateDocumentQuery<TUser>(usersLink, string.Format("SELECT * FROM Users u WHERE udf.HasLogin(u.Logins, '{0}', '{1}') = true", login.ProviderKey, login.LoginProvider)).AsEnumerable();
                         var match = query.AsEnumerable().FirstOrDefault();
                         return match;
                     });


### PR DESCRIPTION
Recent changes to DocumentDB requires the UDFs to be prefixed with lowercase udf.