### PR TITLE
Update packages to latest versions and fix tests

### DIFF
--- a/src/DocumentDB.AspNet.Identity.csproj
+++ b/src/DocumentDB.AspNet.Identity.csproj
@@ -38,13 +38,11 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.DocumentDB.1.8.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.21.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Azure.DocumentDB.1.21.1\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -72,9 +70,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.Azure.DocumentDB.1.8.0\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Azure.DocumentDB.1.8.0\build\Microsoft.Azure.DocumentDB.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Azure.DocumentDB.1.21.1\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Azure.DocumentDB.1.21.1\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
-  <Import Project="packages\Microsoft.Azure.DocumentDB.1.8.0\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('packages\Microsoft.Azure.DocumentDB.1.8.0\build\Microsoft.Azure.DocumentDB.targets')" />
+  <Import Project="packages\Microsoft.Azure.DocumentDB.1.21.1\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('packages\Microsoft.Azure.DocumentDB.1.21.1\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Tests/TestBase.cs
+++ b/src/Tests/TestBase.cs
@@ -1,29 +1,29 @@
-﻿using System;
-using Microsoft.Azure.Documents.Client;
+﻿using Microsoft.Azure.Documents.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Tests
 {
-    public abstract class TestBase
-    {
-        protected DocumentClient Client;
+	public abstract class TestBase
+	{
+		protected DocumentClient Client;
 
-        protected readonly string Endpoint = "";
-        protected readonly string Key = "";
-        protected readonly string Database = "test";
-        protected readonly string Collection = "test";
+		protected readonly string Endpoint = "https://localhost:8081/";
+		protected readonly string Key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+		protected readonly string Database = "test";
+		protected readonly string Collection = "test";
 
-        [TestInitialize]
-        public void Init()
-        {
-            Client = new DocumentClient(new Uri(Endpoint), Key);
-        }
+		[TestInitialize]
+		public void Init()
+		{
+			Client = new DocumentClient(new Uri(Endpoint), Key);
+		}
 
-        [TestCleanup]
-        public void Cleanup()
-        {
-            Client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(Database)).Wait();
-            Client.Dispose();
-        }
-    }
+		[TestCleanup]
+		public void Cleanup()
+		{
+			Client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(Database)).Wait();
+			Client.Dispose();
+		}
+	}
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -42,13 +42,11 @@
     <Reference Include="Microsoft.AspNet.Identity.Core">
       <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.DocumentDB.1.8.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.21.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.DocumentDB.1.21.1\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -108,9 +106,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Azure.DocumentDB.1.8.0\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.DocumentDB.1.8.0\build\Microsoft.Azure.DocumentDB.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Azure.DocumentDB.1.21.1\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.DocumentDB.1.21.1\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Azure.DocumentDB.1.8.0\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\packages\Microsoft.Azure.DocumentDB.1.8.0\build\Microsoft.Azure.DocumentDB.targets')" />
+  <Import Project="..\packages\Microsoft.Azure.DocumentDB.1.21.1\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\packages\Microsoft.Azure.DocumentDB.1.21.1\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Tests/Tests/CustomUserPropertiesTests.cs
+++ b/src/Tests/Tests/CustomUserPropertiesTests.cs
@@ -1,69 +1,69 @@
-﻿using System;
-using System.Threading.Tasks;
-using DocumentDB.AspNet.Identity;
+﻿using DocumentDB.AspNet.Identity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading.Tasks;
 
 namespace Tests.Tests
 {
-    [TestClass]
-    public class CustomUserPropertiesTests : TestBase
-    {
-        private readonly UserStore<TestUserType> _userStore;
+	[TestClass]
+	public class CustomUserPropertiesTests : TestBase
+	{
+		private readonly UserStore<TestUserType> _userStore;
 
-        public CustomUserPropertiesTests()
-        {
-            Init();
-            _userStore = new UserStore<TestUserType>(Client, Database, Collection, true);
-        }
+		public CustomUserPropertiesTests()
+		{
+			Init();
+			_userStore = new UserStore<TestUserType>(Client, Database, Collection, true);
+		}
 
-        private TestUserType _testUser = new TestUserType
-        {
-            UserName = "customtest@test.com",
-            Email = "customtest@test.com",
-            IsAwesome = true,
-            TestTest = "this just some some text..."
-        };
+		private TestUserType _testUser = new TestUserType
+		{
+			UserName = "customtest@test.com",
+			Email = "customtest@test.com",
+			IsAwesome = true,
+			TestTest = "this just some some text..."
+		};
 
-        [TestMethod]
-        public async Task CanCreateUserWithCustomProperties()
-        {
-            await _userStore.CreateAsync(_testUser);
+		[TestMethod]
+		public async Task CanCreateUserWithCustomProperties()
+		{
+			await _userStore.CreateAsync(_testUser);
 
-            var savedUser = await _userStore.FindByEmailAsync(_testUser.Email);
+			var savedUser = await _userStore.FindByEmailAsync(_testUser.Email);
 
-            Assert.IsNotNull(savedUser);
-            Assert.IsTrue(savedUser.IsAwesome);
-            Assert.IsFalse(string.IsNullOrEmpty(savedUser.TestTest));
-            Assert.AreEqual(_testUser.Email, savedUser.Email);
-        }
+			Assert.IsNotNull(savedUser);
+			Assert.IsTrue(savedUser.IsAwesome);
+			Assert.IsFalse(string.IsNullOrEmpty(savedUser.TestTest));
+			Assert.AreEqual(_testUser.Email, savedUser.Email);
+		}
 
-        [TestMethod]
-        public async Task UpdatesAreAppliedToUserWithCustomProperties()
-        {
-            await CanCreateUserWithCustomProperties();
+		[TestMethod]
+		public async Task UpdatesAreAppliedToUserWithCustomProperties()
+		{
+			await CanCreateUserWithCustomProperties();
 
-            var savedUser = await _userStore.FindByEmailAsync(_testUser.Email);
-            if (savedUser == null)
-            {
-                throw new NullReferenceException("savedUser");
-            }
+			var savedUser = await _userStore.FindByEmailAsync(_testUser.Email);
+			if (savedUser == null)
+			{
+				throw new NullReferenceException("savedUser");
+			}
 
-            savedUser.IsAwesome = false;
-            savedUser.TestTest = "test test text";
+			savedUser.IsAwesome = false;
+			savedUser.TestTest = "test test text";
 
-            await _userStore.UpdateAsync(savedUser);
+			await _userStore.UpdateAsync(savedUser);
 
-            savedUser = await _userStore.FindByEmailAsync(_testUser.Email);
+			savedUser = await _userStore.FindByEmailAsync(_testUser.Email);
 
-            Assert.IsNotNull(savedUser);
-            Assert.IsFalse(savedUser.IsAwesome);
-            Assert.AreSame(savedUser.TestTest, "test test text");
-        }
-    }
+			Assert.IsNotNull(savedUser);
+			Assert.IsFalse(savedUser.IsAwesome);
+			Assert.AreEqual(savedUser.TestTest, "test test text");
+		}
+	}
 
-    public class TestUserType : IdentityUser
-    {
-        public bool IsAwesome { get; set; }
-        public string TestTest { get; set; }
-    }
+	public class TestUserType : IdentityUser
+	{
+		public bool IsAwesome { get; set; }
+		public string TestTest { get; set; }
+	}
 }

--- a/src/Tests/app.config
+++ b/src/Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net45" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.8.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.21.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net45" />
 </packages>

--- a/src/app.config
+++ b/src/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net45" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.8.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.21.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Just a small change to update the `Microsoft.Azure.Documents.Client` and `Newtonsoft.Json` NuGet packages to the latest versions. I have a requirement to use these and thought it might be useful to update them in the source @tracker086 ?

I also added connection information in the tests to use the local CosmosDB emulator. There was a failing test due to the use of `Assert.AreSame` - I have changed this to compare the strings using `AreEqual`